### PR TITLE
Fix QA: input validation, STL error handling, dep update

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "dependencies": {
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
-    "@types/three": "^0.182.0",
+    "@types/three": "^0.187.0",
     "lucide-react": "^0.562.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "three": "^0.182.0",
+    "three": "^0.187.0",
     "three-stdlib": "^2.36.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -235,8 +235,14 @@ function App() {
   }
 
   const updateControlPoint = (index: number, field: keyof ControlPoint, val: string) => {
+    const num = parseFloat(val)
+    if (!isFinite(num)) return
+    // Clamp radius to [0.1, 20] and height fraction to [0, 1]
+    const clamped = field === 'r'
+      ? Math.max(0.1, Math.min(20, num))
+      : Math.max(0, Math.min(1, num))
     const newPoints = [...params.controlPoints]
-    newPoints[index] = { ...newPoints[index], [field]: parseFloat(val) }
+    newPoints[index] = { ...newPoints[index], [field]: clamped }
     setParams(prev => ({ ...prev, controlPoints: newPoints }))
   }
 
@@ -286,15 +292,20 @@ function App() {
 
   const exportSTL = () => {
     if (!meshRef.current) return
-    const exporter = new STLExporter()
-    const result = exporter.parse(meshRef.current) as string | ArrayBuffer
-    const blob = new Blob([result], { type: 'model/stl' })
-    const link = document.createElement('a')
-    link.href = URL.createObjectURL(blob)
-    link.setAttribute('download', 'vase-design.stl')
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+    try {
+      const exporter = new STLExporter()
+      const result = exporter.parse(meshRef.current) as string | ArrayBuffer
+      if (!result) throw new Error('Export returned empty result')
+      const blob = new Blob([result], { type: 'model/stl' })
+      const link = document.createElement('a')
+      link.href = URL.createObjectURL(blob)
+      link.setAttribute('download', 'vase-design.stl')
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    } catch (e) {
+      alert('STL export failed: ' + (e instanceof Error ? e.message : String(e)))
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- **#1 (MEDIUM):** Validate control point inputs in `updateControlPoint()` — reject NaN/Infinity, clamp radius to [0.1, 20] and height to [0, 1].
- **#2 (MEDIUM):** Wrap `exportSTL()` in try/catch with user-facing alert on failure.
- **#3 (LOW):** Bump `three` and `@types/three` from 0.182.0 to ^0.187.0.

Closes #1
Closes #2
Closes #3

## Test plan
- [ ] Enter NaN/Infinity in control point fields -- values should be rejected
- [ ] Export STL with valid geometry -- file downloads
- [ ] `npm install` resolves updated three.js version

Generated with [Claude Code](https://claude.com/claude-code)